### PR TITLE
Homework4

### DIFF
--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,34 @@
+# Homework 4. Kubernetes
+
+Проект подготовлен для испольования в kubernetes кластере [google cloud](https://cloud.google.com/kubernetes-engine).
+
+Для работы с кластером необходимо установить:
+ - Google Cloud SDK - [https://cloud.google.com/sdk/docs/install?hl=ru](https://cloud.google.com/sdk/docs/install?hl=ru)
+ - kubectl - [https://kubernetes.io/docs/tasks/tools/](https://kubernetes.io/docs/tasks/tools/)
+ - Lens (опционально) - [https://k8slens.dev/](https://k8slens.dev/)
+
+kubectl должен быть совместимой с google cloud кластером версии.
+
+После настройки кластера и установки приложений необходимо подключить утилиту kubectl к кластеру. 
+Для это необходимо скопировать команду подключения, доступную по кнопке с троеточием в таблице кластеров в консоле google cloud.
+
+Для запуска pod необходимо выполнить команду:
+```
+kubectl apply -f file_name.yaml
+```
+После запуска можно проверить результат с помощью Lens или с помощью команды:
+```
+kubectl describe pod/<pod_name>
+```
+Для осуществления запросов к запущенному контейнеру можно воспользоваться командой:
+```
+kubectl port-forward pod/<pod_name> 80:80
+```
+
+Реализованны следующие манифесты:
+* [online-inference-pod.yaml](./online-inference-pod.yaml) простой Pod;
+* [online-inference-pod-resources.yaml](./online-inference-pod-resources.yaml) простой Pod с указанием ресурсов;
+* [online-inference-pod-probes.yam](./online-inference-pod-probes.yaml) Pod с эмуляцией долгого запуска приложения и последующего падения;
+* [online-inference-replicaset.yaml](./online-inference-replicaset.yaml) ReplicaSet с запуском трех Pod;
+* [online-inference-deployment-blue-green.yaml](./online-inference-deployment-blue-green.yaml) Deployment приложения со cтратегией обновления с предварительным запуском всех Pod с новой версией и последующим отключением со старой;
+* [online-inference-deployment-rolling-update.yaml](./online-inference-deployment-rolling-update.yaml) Deployment приложение со cтратегией постепенного обновления Pod.

--- a/kubernetes/online-inference-pod-blue-green.yaml
+++ b/kubernetes/online-inference-pod-blue-green.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fast-api-deployment
+  labels:
+    app: fast-api-deployment
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app: fast-api-deployment
+  template:
+    metadata:
+      name: fast-api-deployment
+      labels:
+        app: fast-api-deployment
+    spec:
+      containers:
+        - image: arhimisha/ml_in_prod_task_2:v1
+          name: fast-api
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "200m"

--- a/kubernetes/online-inference-pod-probes.yaml
+++ b/kubernetes/online-inference-pod-probes.yaml
@@ -7,6 +7,7 @@ metadata:
 spec:
   containers:
     - image: arhimisha/ml_in_prod_task_2:v2
+      imagePullPolicy: "Always"
       name: fastapi-ml
       ports:
         - containerPort: 80

--- a/kubernetes/online-inference-pod-probes.yaml
+++ b/kubernetes/online-inference-pod-probes.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fastapi-ml-probe
+  labels:
+    app: fastapi-ml-probe
+spec:
+  containers:
+    - image: arhimisha/ml_in_prod_task_2:v2
+      name: fastapi-ml
+      ports:
+        - containerPort: 80
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "500m"
+        limits:
+          memory: "512Mi"
+          cpu: "900m"
+      readinessProbe:
+        httpGet:
+          path: /
+          port: 80
+        initialDelaySeconds: 15
+        periodSeconds: 5
+      livenessProbe:
+        httpGet:
+          path: /healthz
+          port: 80
+        initialDelaySeconds: 40
+        periodSeconds: 3

--- a/kubernetes/online-inference-pod-replicaset.yaml
+++ b/kubernetes/online-inference-pod-replicaset.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: fast-api-replica-set
+  labels:
+    app: fast-api-replica-set
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: fast-api-replica-set
+  template:
+    metadata:
+      name: fast-api-replica-set
+      labels:
+        app: fast-api-replica-set
+    spec:
+      containers:
+        - image: arhimisha/ml_in_prod_task_2:v1
+          name: fast-api
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "200m"

--- a/kubernetes/online-inference-pod-resources.yaml
+++ b/kubernetes/online-inference-pod-resources.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fastapi-ml-resources
+  labels:
+    app: fastapi-ml-resources
+spec:
+  containers:
+    - image: arhimisha/ml_in_prod_task_2:v1
+      name: fastapi-ml
+      ports:
+        - containerPort: 80
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "500m"
+        limits:
+          memory: "512Mi"
+          cpu: "900m"

--- a/kubernetes/online-inference-pod-rolling-update.yaml
+++ b/kubernetes/online-inference-pod-rolling-update.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: fast-api-deployment
+  labels:
+    app: fast-api-deployment
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      app: fast-api-deployment
+  template:
+    metadata:
+      name: fast-api-deployment
+      labels:
+        app: fast-api-deployment
+    spec:
+      containers:
+        - image: arhimisha/ml_in_prod_task_2:v1
+          name: fast-api
+          ports:
+            - containerPort: 80
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "200m"

--- a/kubernetes/online-inference-pod.yaml
+++ b/kubernetes/online-inference-pod.yaml
@@ -10,10 +10,3 @@ spec:
       name: fastapi-ml
       ports:
         - containerPort: 80
-      resources:
-        requests:
-          memory: "128Mi"
-          cpu: "500m"
-        limits:
-          memory: "512Mi"
-          cpu: "900m"

--- a/kubernetes/online-inference-pod.yaml
+++ b/kubernetes/online-inference-pod.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fastapi-ml
+  labels:
+    app: fastapi-ml
+spec:
+  containers:
+    - image: arhimisha/ml_in_prod_task_2:v1
+      name: fastapi-ml
+      ports:
+        - containerPort: 80
+      resources:
+        requests:
+          memory: "128Mi"
+          cpu: "500m"
+        limits:
+          memory: "512Mi"
+          cpu: "900m"

--- a/online_inference/app_predict.py
+++ b/online_inference/app_predict.py
@@ -144,9 +144,9 @@ async def predict(request: XInput):
 async def healthz() -> bool:
     work_time = time.time() - start_time
     if model is not None and work_time < DEAD_DELAY_SECONDS:
-        response = PlainTextResponse(str("OK"), status_code=200)
+        response = PlainTextResponse("OK", status_code=200)
     else:
-        response = PlainTextResponse(str("Bad"), status_code=400)
+        response = PlainTextResponse("Bad", status_code=400)
     return response
 
 

--- a/online_inference/app_predict.py
+++ b/online_inference/app_predict.py
@@ -3,6 +3,7 @@ import logging
 import os
 import pickle
 from typing import List, Union, Optional, NoReturn
+import time
 
 import pandas as pd
 import uvicorn
@@ -14,6 +15,10 @@ from sklearn.svm import LinearSVC
 from sklearn.linear_model import SGDClassifier
 from sklearn.pipeline import Pipeline
 from src.entities.features_info import FeaturesInfo, read_features_info
+
+
+START_DELAY_SECONDS = 30
+DEAD_DELAY_SECONDS = 60
 
 logger = logging.getLogger(__name__)
 log_fmt = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
@@ -96,6 +101,7 @@ def make_predict(
 
 
 app = FastAPI()
+start_time = time.time()
 
 
 @app.get("/")
@@ -108,6 +114,9 @@ def load_model():
     global model
     global transformer
     global features_info
+
+    # delay
+    time.sleep(START_DELAY_SECONDS)
 
     model_path = os.getenv("PATH_TO_MODEL")
     if model_path is None:
@@ -129,6 +138,16 @@ def load_model():
 @app.get("/predict/", response_model=List[YResponse])
 async def predict(request: XInput):
     return make_predict(request.data, request.features, model, transformer, features_info)
+
+
+@app.get("/healthz")
+async def healthz() -> bool:
+    work_time = time.time() - start_time
+    if model is not None and work_time < DEAD_DELAY_SECONDS:
+        response = PlainTextResponse(str("OK"), status_code=200)
+    else:
+        response = PlainTextResponse(str("Bad"), status_code=400)
+    return response
 
 
 @app.exception_handler(RequestValidationError)


### PR DESCRIPTION
# Домашнее задание 4. Знакомство с Kubernetes.

Для выполнения домашнего задания был выбран сервис [Google Cloud](https://cloud.google.com/kubernetes-engine).

1. Информация о кластере:
![1  cluster-info](https://user-images.githubusercontent.com/54512277/122688989-4c909280-d228-11eb-9d86-54db67d07a7b.png)

2. Простой Pod и Pod с ограничениями по ресурсам:
![2  online-inference-pod](https://user-images.githubusercontent.com/54512277/122689053-ba3cbe80-d228-11eb-8bfa-05c9792421e0.png)
Ограничения по ресурсам позволяют точно определить их минимальные значения, а также верхнее ограничение. Их указание позволяет управлять расходованием ресурсов кластера или Namespase'а.

3. Pod c liveness и readiness пробами:
Запуск (работает readiness  проба):
![3  online-inference-probe_1](https://user-images.githubusercontent.com/54512277/122689222-b8bfc600-d229-11eb-85c6-0b04e0c2534c.png)
Штатный режим (readiness и liveness пробы получают ответы со статусом 200 )
![3  online-inference-probe_2](https://user-images.githubusercontent.com/54512277/122689224-bb222000-d229-11eb-9c37-5f6390ee534d.png)
Перезапуск контейнера (liveness проба получила ответ со статусом 400)
![3  online-inference-probe_3](https://user-images.githubusercontent.com/54512277/122689225-bc534d00-d229-11eb-96e8-0074f18f590b.png)
Добавление readiness  пробы позволяет ограничивать трафик на Pod, когда он не готов его принимать, например при первоначальной инициализации контейнера или посреди работы, когда было потеряно соединение с базой данных и он пытается его восстановить.
Добавление liveness пробы позволяет контролировать ситуации когда Pod, перестал корректно работать и его необходимо перезапустить.
4. ReplicaSet c 3 репликами приложения:
![4  online-inference-pod-replicaset](https://user-images.githubusercontent.com/54512277/122689369-c88bda00-d22a-11eb-8087-1b74370389f1.png)
Ответы на вопросы:
    - Если сменить докер образ в манифесте и одновременно с этим уменьшить число реплик, то число реплик уменьшиться до указанного количества, а версии образов останутся старые;
    - Если сменить докер образ в манифесте и одновременно с этим увеличить число реплик, то число реплик увеличиться до указанного количества, версии образов для старых реплик останутся старые, а для всех новых реплик будут новые версии.
5. Deployment приложения:
    - Есть момент времени, когда на кластере есть как все старые поды, так и все новые.
    ![5  online-inference-pod-blue-green](https://user-images.githubusercontent.com/54512277/122689495-8dd67180-d22b-11eb-897b-4b524062c106.png)
Для достижения такого состояния нужно было указать чтобы максимальное число недоступных реплик было 0 (параметр maxUnavaliable), а число дополнительно запускаемых реплик с новой версией образа было 100% (параметр maxSurge)
    - Одновременно с поднятием новых версии, гасятся старые:
    ![5  online-inference-pod-rolling-update](https://user-images.githubusercontent.com/54512277/122689543-0806f600-d22c-11eb-9bd1-d27f30ff519f.png)
Для достижения данного состояния было указанно одинаковое количество Pod для обоих переметров.

Детали выполнения:
:heavy_check_mark: 0. (0 балов) Установка kubectl;
:heavy_check_mark: 1. (5 балов) Развертывание кластера kubernetes;
:heavy_check_mark: 2. (4 баллов) Простой pod manifests;
:heavy_check_mark: 2а. (2 баллов) Использование requests/limits;
:heavy_check_mark: 3. ( 3 баллов) Реализация liveness и readiness проб;
:heavy_check_mark: 4. ( 3 баллов) Реализация ReplicaSet;
:heavy_check_mark: 5. ( 3 баллов) Реализация Deployment; 
:x: 6. ( 5 доп баллов) Установить helm и оформить helm chart;
:heavy_check_mark: 9. (0 балл) Проведена самооценка.

Общий балл - 20.
